### PR TITLE
Add structured error types and hybrid error handling model

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Go bindings to Cairo's powerful vector graphics capabilities.
 - [Installation](#installation)
 - [Quick Example](#quick-example)
 - [Features](#features)
+- [Error Handling](#error-handling)
 - [Performance](#performance)
 - [Comparison to Other Go Graphics Libraries](#comparison-to-other-go-graphics-libraries)
 - [Troubleshooting](#troubleshooting)
@@ -194,6 +195,106 @@ func main() {
 - All types are safe for concurrent use (`sync.RWMutex` internally)
 - Explicit `Close()` methods for deterministic resource release
 - Finalizers as a safety net against leaks
+
+## Error Handling
+
+Go-Cairo uses a hybrid error model that mirrors Cairo's own design.
+
+### Three Error Patterns
+
+**1. Constructors and I/O return `(result, error)`**
+
+```go
+surf, err := cairo.NewImageSurface(cairo.FormatARGB32, 400, 400)
+if err != nil {
+    // err is *cairo.SurfaceError
+}
+
+ctx, err := cairo.NewContext(surf)
+if err != nil {
+    // err is *cairo.ContextError
+}
+```
+
+**2. Drawing operations record status internally**
+
+`Fill`, `Stroke`, `Paint`, and similar operations do not return errors. Check
+the context status after a sequence of drawing calls:
+
+```go
+ctx.MoveTo(10, 10)
+ctx.LineTo(90, 90)
+ctx.Stroke()
+
+if s := ctx.Status(); s != status.Success {
+    return fmt.Errorf("drawing failed: %v", s)
+}
+```
+
+**3. Getters that can fail return `(value, error)`**
+
+```go
+x, y, err := ctx.GetCurrentPoint()
+if err != nil {
+    // err wraps status.NoCurrentPoint — call MoveTo first
+}
+```
+
+### Structured Error Types
+
+The three constructor error types carry extra context alongside the Cairo
+status code:
+
+| Type | Extra field | Example message |
+|------|-------------|-----------------|
+| `*SurfaceError` | `SurfaceType` | `cairo surface error (image): invalid format` |
+| `*ContextError` | `Operation` | `cairo context error (create): null pointer` |
+| `*PatternError` | `PatternType` | `cairo pattern error (linear): invalid matrix` |
+
+All three implement `Unwrap()`, so the full `errors.Is`/`errors.As` chain works.
+
+### Checking Errors with `errors.Is`
+
+Use `errors.Is` to match a specific Cairo status anywhere in the error chain:
+
+```go
+import "github.com/mikowitz/cairo/status"
+
+surf, err := cairo.NewImageSurface(cairo.Format(-1), 400, 400)
+if errors.Is(err, status.InvalidFormat) {
+    // Use a valid format constant such as cairo.FormatARGB32
+}
+```
+
+### Inspecting Errors with `errors.As`
+
+Use `errors.As` to retrieve the structured error and read its context field:
+
+```go
+var surfErr *cairo.SurfaceError
+if errors.As(err, &surfErr) {
+    fmt.Printf("surface type: %s, status: %v\n", surfErr.SurfaceType, surfErr.Status)
+}
+
+var ctxErr *cairo.ContextError
+if errors.As(err, &ctxErr) {
+    fmt.Printf("operation: %s, status: %v\n", ctxErr.Operation, ctxErr.Status)
+}
+```
+
+### Common Errors and Solutions
+
+| Status | Cause | Solution |
+|--------|-------|----------|
+| `status.InvalidFormat` | Invalid surface format constant | Use `FormatARGB32`, `FormatRGB24`, `FormatA8`, or `FormatA1` |
+| `status.NullPointer` | `NewContext` called with a closed or nil surface | Ensure the surface was created successfully and is still open |
+| `status.NoCurrentPoint` | `LineTo`, `Arc`, etc. called before `MoveTo` | Call `MoveTo` to establish a starting point |
+| `status.InvalidRestore` | `Restore` called without a matching `Save` | Balance every `Save` with exactly one `Restore` |
+| `status.SurfaceFinished` | Drawing on a closed surface | Check that `Close` has not been called before drawing is complete |
+| `status.FileNotFound` | Path passed to `WriteToPNG` does not exist | Verify the directory exists and is writable |
+| `status.NoMemory` | Allocation failure, usually a very large surface | Reduce surface dimensions |
+
+See `examples/error_handling.go` for a runnable demonstration of all three patterns.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ if err != nil {
 }
 ```
 
+> Note: getter errors are raw `status.Status` values. Unlike constructor errors, they
+> are not wrapped in `*SurfaceError` or `*ContextError`. Use `errors.Is(err, status.X)`
+> or a `status.Status` type assertion directly.
+
 ### Structured Error Types
 
 The three constructor error types carry extra context alongside the Cairo

--- a/cairo.go
+++ b/cairo.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mikowitz/cairo/context"
 	"github.com/mikowitz/cairo/font"
 	"github.com/mikowitz/cairo/pattern"
-	"github.com/mikowitz/cairo/status"
 	"github.com/mikowitz/cairo/surface"
 )
 
@@ -61,10 +60,7 @@ type Surface = surface.Surface
 func NewImageSurface(format Format, width, height int) (*surface.ImageSurface, error) {
 	surf, err := surface.NewImageSurface(format, width, height)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &SurfaceError{Status: st, SurfaceType: "image"}
-		}
-		return nil, err
+		return nil, wrapSurfaceErr(err, "image")
 	}
 	return surf, nil
 }
@@ -279,10 +275,7 @@ type Context = context.Context
 func NewContext(surface Surface) (*Context, error) {
 	ctx, err := context.NewContext(surface)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &ContextError{Status: st, Operation: "create"}
-		}
-		return nil, err
+		return nil, wrapContextErr(err, "create")
 	}
 	return ctx, nil
 }
@@ -375,10 +368,7 @@ type Pattern = pattern.Pattern
 func NewSolidPatternRGB(r, g, b float64) (*pattern.SolidPattern, error) {
 	p, err := pattern.NewSolidPatternRGB(r, g, b)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &PatternError{Status: st, PatternType: "solid"}
-		}
-		return nil, err
+		return nil, wrapPatternErr(err, "solid")
 	}
 	return p, nil
 }
@@ -423,10 +413,7 @@ func NewSolidPatternRGB(r, g, b float64) (*pattern.SolidPattern, error) {
 func NewSolidPatternRGBA(r, g, b, a float64) (*pattern.SolidPattern, error) {
 	p, err := pattern.NewSolidPatternRGBA(r, g, b, a)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &PatternError{Status: st, PatternType: "solid"}
-		}
-		return nil, err
+		return nil, wrapPatternErr(err, "solid")
 	}
 	return p, nil
 }
@@ -613,10 +600,7 @@ type RadialGradient = pattern.RadialGradient
 func NewLinearGradient(x0, y0, x1, y1 float64) (*LinearGradient, error) {
 	g, err := pattern.NewLinearGradient(x0, y0, x1, y1)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &PatternError{Status: st, PatternType: "linear"}
-		}
-		return nil, err
+		return nil, wrapPatternErr(err, "linear")
 	}
 	return g, nil
 }
@@ -694,10 +678,7 @@ func NewLinearGradient(x0, y0, x1, y1 float64) (*LinearGradient, error) {
 func NewRadialGradient(cx0, cy0, radius0, cx1, cy1, radius1 float64) (*RadialGradient, error) {
 	g, err := pattern.NewRadialGradient(cx0, cy0, radius0, cx1, cy1, radius1)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &PatternError{Status: st, PatternType: "radial"}
-		}
-		return nil, err
+		return nil, wrapPatternErr(err, "radial")
 	}
 	return g, nil
 }
@@ -845,10 +826,7 @@ type SurfacePattern = pattern.SurfacePattern
 func NewSurfacePattern(surface Surface) (*SurfacePattern, error) {
 	p, err := pattern.NewSurfacePattern(surfaceAdapter{surface})
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &PatternError{Status: st, PatternType: "surface"}
-		}
-		return nil, err
+		return nil, wrapPatternErr(err, "surface")
 	}
 	return p, nil
 }

--- a/cairo.go
+++ b/cairo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mikowitz/cairo/context"
 	"github.com/mikowitz/cairo/font"
 	"github.com/mikowitz/cairo/pattern"
+	"github.com/mikowitz/cairo/status"
 	"github.com/mikowitz/cairo/surface"
 )
 
@@ -58,7 +59,14 @@ type Surface = surface.Surface
 // The surface should be closed with Close() when finished to release Cairo resources.
 // A finalizer is registered as a safety net, but explicit cleanup is recommended.
 func NewImageSurface(format Format, width, height int) (*surface.ImageSurface, error) {
-	return surface.NewImageSurface(format, width, height)
+	surf, err := surface.NewImageSurface(format, width, height)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &SurfaceError{Status: st, SurfaceType: "image"}
+		}
+		return nil, err
+	}
+	return surf, nil
 }
 
 // Context is the main object used for drawing operations in Cairo.
@@ -269,7 +277,14 @@ type Context = context.Context
 //
 //	// Use ctx for drawing operations...
 func NewContext(surface Surface) (*Context, error) {
-	return context.NewContext(surface)
+	ctx, err := context.NewContext(surface)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &ContextError{Status: st, Operation: "create"}
+		}
+		return nil, err
+	}
+	return ctx, nil
 }
 
 // Pattern is the interface that all Cairo pattern types implement.
@@ -358,7 +373,14 @@ type Pattern = pattern.Pattern
 //   - Apply transformations to the pattern
 //   - Store patterns for later use
 func NewSolidPatternRGB(r, g, b float64) (*pattern.SolidPattern, error) {
-	return pattern.NewSolidPatternRGB(r, g, b)
+	p, err := pattern.NewSolidPatternRGB(r, g, b)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &PatternError{Status: st, PatternType: "solid"}
+		}
+		return nil, err
+	}
+	return p, nil
 }
 
 // NewSolidPatternRGBA creates a new solid pattern with an RGBA color including transparency.
@@ -399,7 +421,14 @@ func NewSolidPatternRGB(r, g, b float64) (*pattern.SolidPattern, error) {
 //   - Apply transformations to the pattern
 //   - Store patterns for later use
 func NewSolidPatternRGBA(r, g, b, a float64) (*pattern.SolidPattern, error) {
-	return pattern.NewSolidPatternRGBA(r, g, b, a)
+	p, err := pattern.NewSolidPatternRGBA(r, g, b, a)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &PatternError{Status: st, PatternType: "solid"}
+		}
+		return nil, err
+	}
+	return p, nil
 }
 
 // LinearGradient represents a gradient pattern that transitions colors along a line.
@@ -582,7 +611,14 @@ type RadialGradient = pattern.RadialGradient
 //	ctx.SetSource(gradient)
 //	ctx.Paint()  // Creates fade-out effect
 func NewLinearGradient(x0, y0, x1, y1 float64) (*LinearGradient, error) {
-	return pattern.NewLinearGradient(x0, y0, x1, y1)
+	g, err := pattern.NewLinearGradient(x0, y0, x1, y1)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &PatternError{Status: st, PatternType: "linear"}
+		}
+		return nil, err
+	}
+	return g, nil
 }
 
 // NewRadialGradient creates a new radial gradient pattern between two circles.
@@ -656,7 +692,14 @@ func NewLinearGradient(x0, y0, x1, y1 float64) (*LinearGradient, error) {
 //	ctx.Arc(150, 150, 100, 0, 2*math.Pi)
 //	ctx.Fill()  // Creates glow effect
 func NewRadialGradient(cx0, cy0, radius0, cx1, cy1, radius1 float64) (*RadialGradient, error) {
-	return pattern.NewRadialGradient(cx0, cy0, radius0, cx1, cy1, radius1)
+	g, err := pattern.NewRadialGradient(cx0, cy0, radius0, cx1, cy1, radius1)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &PatternError{Status: st, PatternType: "radial"}
+		}
+		return nil, err
+	}
+	return g, nil
 }
 
 // SurfacePattern represents a pattern based on a Cairo surface (image).
@@ -800,7 +843,14 @@ type SurfacePattern = pattern.SurfacePattern
 //	ctx.Rectangle(0, 0, 400, 300)
 //	ctx.Fill()
 func NewSurfacePattern(surface Surface) (*SurfacePattern, error) {
-	return pattern.NewSurfacePattern(surfaceAdapter{surface})
+	p, err := pattern.NewSurfacePattern(surfaceAdapter{surface})
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &PatternError{Status: st, PatternType: "surface"}
+		}
+		return nil, err
+	}
+	return p, nil
 }
 
 // surfaceAdapter adapts surface.Surface to work with pattern.NewSurfacePattern.

--- a/cairo_pdf.go
+++ b/cairo_pdf.go
@@ -5,7 +5,10 @@
 
 package cairo
 
-import "github.com/mikowitz/cairo/surface"
+import (
+	"github.com/mikowitz/cairo/status"
+	"github.com/mikowitz/cairo/surface"
+)
 
 // PDFSurface is a surface that writes drawing operations to a PDF file.
 // Dimensions are specified in points, where 1 point equals 1/72 of an inch.
@@ -25,5 +28,12 @@ type PDFSurface = surface.PDFSurface
 // Requires the Cairo PDF backend. On Debian/Ubuntu: libcairo2-dev.
 // On macOS: brew install cairo (includes PDF support by default).
 func NewPDFSurface(filename string, widthPt, heightPt float64) (*PDFSurface, error) {
-	return surface.NewPDFSurface(filename, widthPt, heightPt)
+	surf, err := surface.NewPDFSurface(filename, widthPt, heightPt)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &SurfaceError{Status: st, SurfaceType: "pdf"}
+		}
+		return nil, err
+	}
+	return surf, nil
 }

--- a/cairo_pdf.go
+++ b/cairo_pdf.go
@@ -5,10 +5,7 @@
 
 package cairo
 
-import (
-	"github.com/mikowitz/cairo/status"
-	"github.com/mikowitz/cairo/surface"
-)
+import "github.com/mikowitz/cairo/surface"
 
 // PDFSurface is a surface that writes drawing operations to a PDF file.
 // Dimensions are specified in points, where 1 point equals 1/72 of an inch.
@@ -30,10 +27,7 @@ type PDFSurface = surface.PDFSurface
 func NewPDFSurface(filename string, widthPt, heightPt float64) (*PDFSurface, error) {
 	surf, err := surface.NewPDFSurface(filename, widthPt, heightPt)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &SurfaceError{Status: st, SurfaceType: "pdf"}
-		}
-		return nil, err
+		return nil, wrapSurfaceErr(err, "pdf")
 	}
 	return surf, nil
 }

--- a/cairo_svg.go
+++ b/cairo_svg.go
@@ -5,7 +5,10 @@
 
 package cairo
 
-import "github.com/mikowitz/cairo/surface"
+import (
+	"github.com/mikowitz/cairo/status"
+	"github.com/mikowitz/cairo/surface"
+)
 
 // SVGSurface is a surface that writes drawing operations to an SVG file.
 // Dimensions are specified in points, where 1 point equals 1/72 of an inch.
@@ -73,5 +76,12 @@ func SVGVersionToString(version SVGVersion) string {
 // Requires the Cairo SVG backend. On Debian/Ubuntu: libcairo2-dev.
 // On macOS: brew install cairo (includes SVG support by default).
 func NewSVGSurface(filename string, widthPt, heightPt float64) (*SVGSurface, error) {
-	return surface.NewSVGSurface(filename, widthPt, heightPt)
+	surf, err := surface.NewSVGSurface(filename, widthPt, heightPt)
+	if err != nil {
+		if st, ok := err.(status.Status); ok {
+			return nil, &SurfaceError{Status: st, SurfaceType: "svg"}
+		}
+		return nil, err
+	}
+	return surf, nil
 }

--- a/cairo_svg.go
+++ b/cairo_svg.go
@@ -5,10 +5,7 @@
 
 package cairo
 
-import (
-	"github.com/mikowitz/cairo/status"
-	"github.com/mikowitz/cairo/surface"
-)
+import "github.com/mikowitz/cairo/surface"
 
 // SVGSurface is a surface that writes drawing operations to an SVG file.
 // Dimensions are specified in points, where 1 point equals 1/72 of an inch.
@@ -78,10 +75,7 @@ func SVGVersionToString(version SVGVersion) string {
 func NewSVGSurface(filename string, widthPt, heightPt float64) (*SVGSurface, error) {
 	surf, err := surface.NewSVGSurface(filename, widthPt, heightPt)
 	if err != nil {
-		if st, ok := err.(status.Status); ok {
-			return nil, &SurfaceError{Status: st, SurfaceType: "svg"}
-		}
-		return nil, err
+		return nil, wrapSurfaceErr(err, "svg")
 	}
 	return surf, nil
 }

--- a/context/line_style.go
+++ b/context/line_style.go
@@ -180,7 +180,10 @@ func (c *Context) SetDash(dashes []float64, offset float64) error {
 		return status.InvalidDash
 	}
 
-	return contextSetDash(c.ptr, dashes, offset).ToError()
+	if st := contextSetDash(c.ptr, dashes, offset); st != status.Success {
+		return st
+	}
+	return nil
 }
 
 func anyNegative(s []float64) bool {

--- a/errors.go
+++ b/errors.go
@@ -33,6 +33,7 @@ func (e *SurfaceError) Unwrap() error {
 // Is reports whether target matches this error.
 // It matches if target is a *SurfaceError with the same Status,
 // and either target.SurfaceType is empty or equals e.SurfaceType.
+// An empty target.SurfaceType acts as a wildcard and matches any surface type.
 func (e *SurfaceError) Is(target error) bool {
 	t, ok := target.(*SurfaceError)
 	if !ok {
@@ -69,6 +70,7 @@ func (e *ContextError) Unwrap() error {
 // Is reports whether target matches this error.
 // It matches if target is a *ContextError with the same Status,
 // and either target.Operation is empty or equals e.Operation.
+// An empty target.Operation acts as a wildcard and matches any operation.
 func (e *ContextError) Is(target error) bool {
 	t, ok := target.(*ContextError)
 	if !ok {
@@ -105,6 +107,7 @@ func (e *PatternError) Unwrap() error {
 // Is reports whether target matches this error.
 // It matches if target is a *PatternError with the same Status,
 // and either target.PatternType is empty or equals e.PatternType.
+// An empty target.PatternType acts as a wildcard and matches any pattern type.
 func (e *PatternError) Is(target error) bool {
 	t, ok := target.(*PatternError)
 	if !ok {

--- a/errors.go
+++ b/errors.go
@@ -116,3 +116,29 @@ func (e *PatternError) Is(target error) bool {
 	return e.Status == t.Status
 }
 
+// wrapSurfaceErr converts a status.Status error into a *SurfaceError with the
+// given surface type. Non-status errors pass through unchanged.
+func wrapSurfaceErr(err error, surfaceType string) error {
+	if st, ok := err.(status.Status); ok {
+		return &SurfaceError{Status: st, SurfaceType: surfaceType}
+	}
+	return err
+}
+
+// wrapContextErr converts a status.Status error into a *ContextError with the
+// given operation name. Non-status errors pass through unchanged.
+func wrapContextErr(err error, operation string) error {
+	if st, ok := err.(status.Status); ok {
+		return &ContextError{Status: st, Operation: operation}
+	}
+	return err
+}
+
+// wrapPatternErr converts a status.Status error into a *PatternError with the
+// given pattern type. Non-status errors pass through unchanged.
+func wrapPatternErr(err error, patternType string) error {
+	if st, ok := err.(status.Status); ok {
+		return &PatternError{Status: st, PatternType: patternType}
+	}
+	return err
+}

--- a/errors.go
+++ b/errors.go
@@ -44,16 +44,6 @@ func (e *SurfaceError) Is(target error) bool {
 	return e.Status == t.Status
 }
 
-// As finds the first error in the chain that matches target.
-func (e *SurfaceError) As(target any) bool {
-	t, ok := target.(**SurfaceError)
-	if ok {
-		*t = e
-		return true
-	}
-	return false
-}
-
 // ContextError represents an error that occurred during a context drawing operation.
 // It wraps a status.Status value and includes the operation name for additional context.
 type ContextError struct {
@@ -88,16 +78,6 @@ func (e *ContextError) Is(target error) bool {
 		return false
 	}
 	return e.Status == t.Status
-}
-
-// As finds the first error in the chain that matches target.
-func (e *ContextError) As(target any) bool {
-	t, ok := target.(**ContextError)
-	if ok {
-		*t = e
-		return true
-	}
-	return false
 }
 
 // PatternError represents an error that occurred during a pattern operation.
@@ -136,12 +116,3 @@ func (e *PatternError) Is(target error) bool {
 	return e.Status == t.Status
 }
 
-// As finds the first error in the chain that matches target.
-func (e *PatternError) As(target any) bool {
-	t, ok := target.(**PatternError)
-	if ok {
-		*t = e
-		return true
-	}
-	return false
-}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,147 @@
+// ABOUTME: Custom error types for Cairo surface, context, and pattern operations.
+// ABOUTME: Provides structured errors wrapping status codes with additional context.
+package cairo
+
+import (
+	"fmt"
+
+	"github.com/mikowitz/cairo/status"
+)
+
+// SurfaceError represents an error that occurred during a surface operation.
+// It wraps a status.Status value and includes the surface type for additional context.
+type SurfaceError struct {
+	// Status is the underlying Cairo status code.
+	Status status.Status
+	// SurfaceType identifies the kind of surface (e.g., "image", "pdf", "svg").
+	SurfaceType string
+}
+
+// Error implements the error interface.
+func (e *SurfaceError) Error() string {
+	if e.SurfaceType != "" {
+		return fmt.Sprintf("cairo surface error (%s): %v", e.SurfaceType, e.Status)
+	}
+	return fmt.Sprintf("cairo surface error: %v", e.Status)
+}
+
+// Unwrap returns the underlying status error for use with errors.Is and errors.As.
+func (e *SurfaceError) Unwrap() error {
+	return e.Status
+}
+
+// Is reports whether target matches this error.
+// It matches if target is a *SurfaceError with the same Status,
+// and either target.SurfaceType is empty or equals e.SurfaceType.
+func (e *SurfaceError) Is(target error) bool {
+	t, ok := target.(*SurfaceError)
+	if !ok {
+		return false
+	}
+	if t.SurfaceType != "" && t.SurfaceType != e.SurfaceType {
+		return false
+	}
+	return e.Status == t.Status
+}
+
+// As finds the first error in the chain that matches target.
+func (e *SurfaceError) As(target any) bool {
+	t, ok := target.(**SurfaceError)
+	if ok {
+		*t = e
+		return true
+	}
+	return false
+}
+
+// ContextError represents an error that occurred during a context drawing operation.
+// It wraps a status.Status value and includes the operation name for additional context.
+type ContextError struct {
+	// Status is the underlying Cairo status code.
+	Status status.Status
+	// Operation names the drawing operation that failed (e.g., "stroke", "fill").
+	Operation string
+}
+
+// Error implements the error interface.
+func (e *ContextError) Error() string {
+	if e.Operation != "" {
+		return fmt.Sprintf("cairo context error (%s): %v", e.Operation, e.Status)
+	}
+	return fmt.Sprintf("cairo context error: %v", e.Status)
+}
+
+// Unwrap returns the underlying status error for use with errors.Is and errors.As.
+func (e *ContextError) Unwrap() error {
+	return e.Status
+}
+
+// Is reports whether target matches this error.
+// It matches if target is a *ContextError with the same Status,
+// and either target.Operation is empty or equals e.Operation.
+func (e *ContextError) Is(target error) bool {
+	t, ok := target.(*ContextError)
+	if !ok {
+		return false
+	}
+	if t.Operation != "" && t.Operation != e.Operation {
+		return false
+	}
+	return e.Status == t.Status
+}
+
+// As finds the first error in the chain that matches target.
+func (e *ContextError) As(target any) bool {
+	t, ok := target.(**ContextError)
+	if ok {
+		*t = e
+		return true
+	}
+	return false
+}
+
+// PatternError represents an error that occurred during a pattern operation.
+// It wraps a status.Status value and includes the pattern type for additional context.
+type PatternError struct {
+	// Status is the underlying Cairo status code.
+	Status status.Status
+	// PatternType identifies the kind of pattern (e.g., "solid", "linear", "radial").
+	PatternType string
+}
+
+// Error implements the error interface.
+func (e *PatternError) Error() string {
+	if e.PatternType != "" {
+		return fmt.Sprintf("cairo pattern error (%s): %v", e.PatternType, e.Status)
+	}
+	return fmt.Sprintf("cairo pattern error: %v", e.Status)
+}
+
+// Unwrap returns the underlying status error for use with errors.Is and errors.As.
+func (e *PatternError) Unwrap() error {
+	return e.Status
+}
+
+// Is reports whether target matches this error.
+// It matches if target is a *PatternError with the same Status,
+// and either target.PatternType is empty or equals e.PatternType.
+func (e *PatternError) Is(target error) bool {
+	t, ok := target.(*PatternError)
+	if !ok {
+		return false
+	}
+	if t.PatternType != "" && t.PatternType != e.PatternType {
+		return false
+	}
+	return e.Status == t.Status
+}
+
+// As finds the first error in the chain that matches target.
+func (e *PatternError) As(target any) bool {
+	t, ok := target.(**PatternError)
+	if ok {
+		*t = e
+		return true
+	}
+	return false
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,136 @@
+// ABOUTME: Tests for custom Cairo error types (SurfaceError, ContextError, PatternError).
+// ABOUTME: Verifies errors.Is, errors.As, error messages, and type assertions.
+package cairo_test
+
+import (
+	"errors"
+	"testing"
+
+	cairo "github.com/mikowitz/cairo"
+	"github.com/mikowitz/cairo/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorTypes(t *testing.T) {
+	t.Run("SurfaceError type assertion via errors.As", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat, SurfaceType: "image"}
+		var se *cairo.SurfaceError
+		require.True(t, errors.As(surfErr, &se))
+		assert.Equal(t, status.InvalidFormat, se.Status)
+		assert.Equal(t, "image", se.SurfaceType)
+	})
+
+	t.Run("ContextError type assertion via errors.As", func(t *testing.T) {
+		ctxErr := &cairo.ContextError{Status: status.NoCurrentPoint, Operation: "stroke"}
+		var ce *cairo.ContextError
+		require.True(t, errors.As(ctxErr, &ce))
+		assert.Equal(t, status.NoCurrentPoint, ce.Status)
+		assert.Equal(t, "stroke", ce.Operation)
+	})
+
+	t.Run("PatternError type assertion via errors.As", func(t *testing.T) {
+		patErr := &cairo.PatternError{Status: status.PatternTypeMismatch, PatternType: "linear"}
+		var pe *cairo.PatternError
+		require.True(t, errors.As(patErr, &pe))
+		assert.Equal(t, status.PatternTypeMismatch, pe.Status)
+		assert.Equal(t, "linear", pe.PatternType)
+	})
+
+	t.Run("errors.As returns false for wrong type", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat}
+		var ce *cairo.ContextError
+		assert.False(t, errors.As(surfErr, &ce))
+	})
+}
+
+func TestErrorUnwrapping(t *testing.T) {
+	t.Run("SurfaceError unwraps to status", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat}
+		assert.True(t, errors.Is(surfErr, status.InvalidFormat))
+		assert.False(t, errors.Is(surfErr, status.NoCurrentPoint))
+	})
+
+	t.Run("ContextError unwraps to status", func(t *testing.T) {
+		ctxErr := &cairo.ContextError{Status: status.NoCurrentPoint}
+		assert.True(t, errors.Is(ctxErr, status.NoCurrentPoint))
+		assert.False(t, errors.Is(ctxErr, status.InvalidFormat))
+	})
+
+	t.Run("PatternError unwraps to status", func(t *testing.T) {
+		patErr := &cairo.PatternError{Status: status.PatternTypeMismatch}
+		assert.True(t, errors.Is(patErr, status.PatternTypeMismatch))
+		assert.False(t, errors.Is(patErr, status.InvalidFormat))
+	})
+
+	t.Run("errors.Is with matching SurfaceError", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat, SurfaceType: "image"}
+		target := &cairo.SurfaceError{Status: status.InvalidFormat}
+		assert.True(t, errors.Is(surfErr, target))
+	})
+
+	t.Run("errors.Is with mismatched SurfaceType", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat, SurfaceType: "image"}
+		target := &cairo.SurfaceError{Status: status.InvalidFormat, SurfaceType: "pdf"}
+		assert.False(t, errors.Is(surfErr, target))
+	})
+
+	t.Run("errors.Is with matching ContextError", func(t *testing.T) {
+		ctxErr := &cairo.ContextError{Status: status.NoCurrentPoint, Operation: "stroke"}
+		target := &cairo.ContextError{Status: status.NoCurrentPoint}
+		assert.True(t, errors.Is(ctxErr, target))
+	})
+
+	t.Run("errors.Is with mismatched Operation", func(t *testing.T) {
+		ctxErr := &cairo.ContextError{Status: status.NoCurrentPoint, Operation: "stroke"}
+		target := &cairo.ContextError{Status: status.NoCurrentPoint, Operation: "fill"}
+		assert.False(t, errors.Is(ctxErr, target))
+	})
+
+	t.Run("errors.Is with matching PatternError", func(t *testing.T) {
+		patErr := &cairo.PatternError{Status: status.PatternTypeMismatch, PatternType: "linear"}
+		target := &cairo.PatternError{Status: status.PatternTypeMismatch}
+		assert.True(t, errors.Is(patErr, target))
+	})
+
+	t.Run("errors.Is with mismatched PatternType", func(t *testing.T) {
+		patErr := &cairo.PatternError{Status: status.PatternTypeMismatch, PatternType: "linear"}
+		target := &cairo.PatternError{Status: status.PatternTypeMismatch, PatternType: "solid"}
+		assert.False(t, errors.Is(patErr, target))
+	})
+}
+
+func TestErrorContext(t *testing.T) {
+	t.Run("SurfaceError includes surface type in message", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat, SurfaceType: "image"}
+		assert.Contains(t, surfErr.Error(), "image")
+	})
+
+	t.Run("SurfaceError without surface type has simpler message", func(t *testing.T) {
+		surfErr := &cairo.SurfaceError{Status: status.InvalidFormat}
+		assert.Contains(t, surfErr.Error(), "cairo surface error")
+		assert.NotContains(t, surfErr.Error(), "()")
+	})
+
+	t.Run("ContextError includes operation in message", func(t *testing.T) {
+		ctxErr := &cairo.ContextError{Status: status.NoCurrentPoint, Operation: "stroke"}
+		assert.Contains(t, ctxErr.Error(), "stroke")
+	})
+
+	t.Run("ContextError without operation has simpler message", func(t *testing.T) {
+		ctxErr := &cairo.ContextError{Status: status.NoCurrentPoint}
+		assert.Contains(t, ctxErr.Error(), "cairo context error")
+		assert.NotContains(t, ctxErr.Error(), "()")
+	})
+
+	t.Run("PatternError includes pattern type in message", func(t *testing.T) {
+		patErr := &cairo.PatternError{Status: status.PatternTypeMismatch, PatternType: "linear"}
+		assert.Contains(t, patErr.Error(), "linear")
+	})
+
+	t.Run("PatternError without pattern type has simpler message", func(t *testing.T) {
+		patErr := &cairo.PatternError{Status: status.PatternTypeMismatch}
+		assert.Contains(t, patErr.Error(), "cairo pattern error")
+		assert.NotContains(t, patErr.Error(), "()")
+	})
+}

--- a/examples/error_handling.go
+++ b/examples/error_handling.go
@@ -1,0 +1,116 @@
+// ABOUTME: Example demonstrating proper error handling patterns for the cairo library.
+// ABOUTME: Shows errors.Is/As usage, typed error inspection, and drawing status checking.
+package examples
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/mikowitz/cairo"
+	"github.com/mikowitz/cairo/status"
+)
+
+// ErrorHandlingResult captures results from the error handling demonstration.
+type ErrorHandlingResult struct {
+	// InvalidFormatErr is the error from creating a surface with an invalid format.
+	InvalidFormatErr error
+	// NilSurfaceErr is the error from creating a context with a nil surface.
+	NilSurfaceErr error
+	// NoCurrentPointErr is the error from querying current point before any MoveTo.
+	NoCurrentPointErr error
+}
+
+// DemonstrateErrorHandling exercises the cairo error handling APIs and returns
+// the errors encountered so callers can inspect them.
+//
+// This example shows three error handling patterns:
+//
+//  1. Constructor errors: NewImageSurface, NewContext return (value, error).
+//     Use errors.Is to check the specific status and errors.As to inspect the
+//     typed error fields (SurfaceType, Operation, PatternType).
+//
+//  2. Drawing status: drawing operations do not return errors. After a sequence
+//     of drawing calls, inspect ctx.Status() to detect failures.
+//
+//  3. Getter errors: methods like GetCurrentPoint return (value, error) when
+//     the operation can fail due to invalid state.
+func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
+	var result ErrorHandlingResult
+
+	// --- Pattern 1: constructor errors with errors.Is and errors.As ---
+
+	// Attempt to create a surface with an invalid format.
+	// NewImageSurface wraps the failure in a *cairo.SurfaceError.
+	_, err := cairo.NewImageSurface(cairo.Format(-1), 100, 100)
+	if err != nil {
+		result.InvalidFormatErr = err
+
+		// errors.Is traverses the error chain; SurfaceError.Unwrap returns the
+		// underlying status.Status, so this check reaches the raw status code.
+		if !errors.Is(err, status.InvalidFormat) {
+			return result, fmt.Errorf("expected InvalidFormat status, got: %w", err)
+		}
+
+		// errors.As extracts the typed wrapper to read the SurfaceType field.
+		var surfErr *cairo.SurfaceError
+		if errors.As(err, &surfErr) {
+			_ = surfErr.SurfaceType // "image" — identifies which surface type failed
+		}
+	}
+
+	// Attempt to create a context with a nil surface.
+	// NewContext wraps the failure in a *cairo.ContextError.
+	_, err = cairo.NewContext(nil)
+	if err != nil {
+		result.NilSurfaceErr = err
+
+		if !errors.Is(err, status.NullPointer) {
+			return result, fmt.Errorf("expected NullPointer status, got: %w", err)
+		}
+
+		var ctxErr *cairo.ContextError
+		if errors.As(err, &ctxErr) {
+			_ = ctxErr.Operation // "create" — identifies the failing operation
+		}
+	}
+
+	// --- Pattern 2: getter errors for invalid state ---
+
+	// Create a valid surface and context for the remaining patterns.
+	surf, err := cairo.NewImageSurface(cairo.FormatARGB32, 200, 200)
+	if err != nil {
+		return result, fmt.Errorf("creating surface: %w", err)
+	}
+	defer surf.Close()
+
+	ctx, err := cairo.NewContext(surf)
+	if err != nil {
+		return result, fmt.Errorf("creating context: %w", err)
+	}
+	defer ctx.Close()
+
+	// GetCurrentPoint fails when no path exists yet.
+	_, _, err = ctx.GetCurrentPoint()
+	if err != nil {
+		result.NoCurrentPointErr = err
+
+		if !errors.Is(err, status.NoCurrentPoint) {
+			return result, fmt.Errorf("expected NoCurrentPoint status, got: %w", err)
+		}
+	}
+
+	// --- Pattern 3: drawing operation status checking ---
+
+	// Drawing calls like MoveTo, LineTo, Stroke do not return errors.
+	// Check ctx.Status() after a sequence to detect any failure.
+	ctx.MoveTo(10, 10)
+	ctx.LineTo(190, 190)
+	ctx.SetLineWidth(2)
+	ctx.Stroke()
+
+	if s := ctx.Status(); s != status.Success {
+		return result, fmt.Errorf("drawing failed: %v", s)
+	}
+
+	return result, nil
+}

--- a/examples/error_handling.go
+++ b/examples/error_handling.go
@@ -74,7 +74,7 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 		}
 	}
 
-	// --- Pattern 2: getter errors for invalid state ---
+	// --- Pattern 3: getter errors for invalid state ---
 
 	// Create a valid surface and context for the remaining patterns.
 	surf, err := cairo.NewImageSurface(cairo.FormatARGB32, 200, 200)
@@ -99,7 +99,7 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 		}
 	}
 
-	// --- Pattern 3: drawing operation status checking ---
+	// --- Pattern 2: drawing operation status checking ---
 
 	// Drawing calls like MoveTo, LineTo, Stroke do not return errors.
 	// Check ctx.Status() after a sequence to detect any failure.

--- a/examples/error_handling.go
+++ b/examples/error_handling.go
@@ -16,7 +16,7 @@ type ErrorHandlingResult struct {
 	InvalidFormatErr error
 	// NilSurfaceErr is the error from creating a context with a nil surface.
 	NilSurfaceErr error
-	// NoCurrentPointErr is the error from querying current point before any MoveTo.
+	// NoCurrentPointErr is the error from querying current point when no path is active.
 	NoCurrentPointErr error
 }
 
@@ -73,7 +73,6 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 		}
 	}
 
-	// --- Pattern 3: getter errors for invalid state ---
 	// Create a valid surface and context for the remaining patterns.
 	surf, err := cairo.NewImageSurface(cairo.FormatARGB32, 200, 200)
 	if err != nil {
@@ -87,18 +86,7 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 	}
 	defer func() { _ = ctx.Close() }()
 
-	// GetCurrentPoint fails when no path exists yet.
-	_, _, err = ctx.GetCurrentPoint()
-	if err != nil {
-		result.NoCurrentPointErr = err
-
-		if !errors.Is(err, status.NoCurrentPoint) {
-			return result, fmt.Errorf("expected NoCurrentPoint status, got: %w", err)
-		}
-	}
-
 	// --- Pattern 2: drawing operation status checking ---
-
 	// Drawing calls like MoveTo, LineTo, Stroke do not return errors.
 	// Check ctx.Status() after a sequence to detect any failure.
 	ctx.MoveTo(10, 10)
@@ -108,6 +96,18 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 
 	if s := ctx.Status(); s != status.Success {
 		return result, fmt.Errorf("drawing failed: %v", s)
+	}
+
+	// --- Pattern 3: getter errors for invalid state ---
+	// Stroke clears the current path and current point, so GetCurrentPoint
+	// now returns NoCurrentPoint — the same failure as before any MoveTo.
+	_, _, err = ctx.GetCurrentPoint()
+	if err != nil {
+		result.NoCurrentPointErr = err
+
+		if !errors.Is(err, status.NoCurrentPoint) {
+			return result, fmt.Errorf("expected NoCurrentPoint status, got: %w", err)
+		}
 	}
 
 	return result, nil

--- a/examples/error_handling.go
+++ b/examples/error_handling.go
@@ -38,7 +38,6 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 	var result ErrorHandlingResult
 
 	// --- Pattern 1: constructor errors with errors.Is and errors.As ---
-
 	// Attempt to create a surface with an invalid format.
 	// NewImageSurface wraps the failure in a *cairo.SurfaceError.
 	_, err := cairo.NewImageSurface(cairo.Format(-1), 100, 100)
@@ -75,19 +74,18 @@ func DemonstrateErrorHandling() (ErrorHandlingResult, error) {
 	}
 
 	// --- Pattern 3: getter errors for invalid state ---
-
 	// Create a valid surface and context for the remaining patterns.
 	surf, err := cairo.NewImageSurface(cairo.FormatARGB32, 200, 200)
 	if err != nil {
 		return result, fmt.Errorf("creating surface: %w", err)
 	}
-	defer surf.Close()
+	defer func() { _ = surf.Close() }()
 
 	ctx, err := cairo.NewContext(surf)
 	if err != nil {
 		return result, fmt.Errorf("creating context: %w", err)
 	}
-	defer ctx.Close()
+	defer func() { _ = ctx.Close() }()
 
 	// GetCurrentPoint fails when no path exists yet.
 	_, _, err = ctx.GetCurrentPoint()

--- a/examples/error_handling_test.go
+++ b/examples/error_handling_test.go
@@ -1,0 +1,76 @@
+// ABOUTME: Tests for the error handling example in the cairo library.
+// ABOUTME: Verifies that error handling patterns work correctly and produce expected errors.
+package examples
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mikowitz/cairo"
+	"github.com/mikowitz/cairo/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDemonstrateErrorHandlingSucceeds(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	assert.NotNil(t, result.InvalidFormatErr, "should have captured an invalid format error")
+	assert.NotNil(t, result.NilSurfaceErr, "should have captured a nil surface error")
+	assert.NotNil(t, result.NoCurrentPointErr, "should have captured a no current point error")
+}
+
+func TestInvalidFormatErrorIsSurfaceError(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	var surfErr *cairo.SurfaceError
+	require.True(t, errors.As(result.InvalidFormatErr, &surfErr), "invalid format error should be a *SurfaceError")
+	assert.Equal(t, "image", surfErr.SurfaceType)
+	assert.Equal(t, status.InvalidFormat, surfErr.Status)
+}
+
+func TestInvalidFormatErrorIsStatusCheck(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	assert.True(t, errors.Is(result.InvalidFormatErr, status.InvalidFormat),
+		"errors.Is should match InvalidFormat through the SurfaceError chain")
+}
+
+func TestNilSurfaceErrorIsContextError(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	var ctxErr *cairo.ContextError
+	require.True(t, errors.As(result.NilSurfaceErr, &ctxErr), "nil surface error should be a *ContextError")
+	assert.Equal(t, "create", ctxErr.Operation)
+	assert.Equal(t, status.NullPointer, ctxErr.Status)
+}
+
+func TestNilSurfaceErrorIsStatusCheck(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	assert.True(t, errors.Is(result.NilSurfaceErr, status.NullPointer),
+		"errors.Is should match NullPointer through the ContextError chain")
+}
+
+func TestNoCurrentPointErrorIsStatusCheck(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	assert.True(t, errors.Is(result.NoCurrentPointErr, status.NoCurrentPoint),
+		"errors.Is should match NoCurrentPoint status")
+}
+
+func TestErrorMessageIncludesContext(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	assert.Contains(t, result.InvalidFormatErr.Error(), "image",
+		"surface error message should include the surface type")
+	assert.Contains(t, result.NilSurfaceErr.Error(), "create",
+		"context error message should include the operation name")
+}

--- a/examples/error_handling_test.go
+++ b/examples/error_handling_test.go
@@ -65,6 +65,16 @@ func TestNoCurrentPointErrorIsStatusCheck(t *testing.T) {
 		"errors.Is should match NoCurrentPoint status")
 }
 
+func TestNoCurrentPointErrorIsRawStatus(t *testing.T) {
+	result, err := DemonstrateErrorHandling()
+	require.NoError(t, err)
+
+	var st status.Status
+	require.True(t, errors.As(result.NoCurrentPointErr, &st),
+		"getter errors are raw status.Status values, not wrapped error types")
+	assert.Equal(t, status.NoCurrentPoint, st)
+}
+
 func TestErrorMessageIncludesContext(t *testing.T) {
 	result, err := DemonstrateErrorHandling()
 	require.NoError(t, err)

--- a/matrix/matrix_cgo.go
+++ b/matrix/matrix_cgo.go
@@ -106,7 +106,10 @@ func matrixTransformDistance(m *Matrix, dx, dy float64) (float64, float64) {
 func matrixInvert(m *Matrix) error {
 	st := status.Status(C.cairo_matrix_invert(m.ptr))
 	m.updateFromC()
-	return st.ToError()
+	if st == status.Success {
+		return nil
+	}
+	return st
 }
 
 func matrixMultiply(m, n *Matrix) *Matrix {

--- a/status/doc.go
+++ b/status/doc.go
@@ -137,6 +137,5 @@ The only recovery is to close the object and create a new one.
   2. Use defer for Close() immediately after successful construction
   3. Check Status() before expensive operations or before saving results
   4. Wrap errors with context using fmt.Errorf("context: %w", err)
-  5. Use Status.ToError() to convert status to standard error if needed
 */
 package status

--- a/status/status.go
+++ b/status/status.go
@@ -3,7 +3,6 @@
 //go:generate stringer -type=Status
 package status
 
-
 // Status is used to indicate errors that can occur when using
 // Cairo. In some cases it is returned directly by functions.
 // But when using `Context`, the last error, if any, is stored
@@ -107,4 +106,3 @@ func statusSuggestion(s Status) string {
 	}
 	return ""
 }
-

--- a/status/status.go
+++ b/status/status.go
@@ -64,6 +64,11 @@ const (
 	LastStatus
 )
 
+// Error returns the status name followed by an actionable suggestion for
+// common statuses (e.g. "NoCurrentPoint: call MoveTo before path operations
+// like LineTo or Arc"). For statuses with no suggestion, it returns only the
+// status name (e.g. "NullPointer"). Do not match on the exact string returned
+// by Error(); use errors.Is instead.
 func (s Status) Error() string {
 	base := s.toString()
 	if suggestion := statusSuggestion(s); suggestion != "" {

--- a/status/status.go
+++ b/status/status.go
@@ -1,3 +1,5 @@
+// ABOUTME: Defines the Status type mapping Cairo error codes to Go errors.
+// ABOUTME: Provides descriptive Error() messages with actionable suggestions for common statuses.
 //go:generate stringer -type=Status
 package status
 
@@ -63,7 +65,43 @@ const (
 )
 
 func (s Status) Error() string {
-	return s.toString()
+	base := s.toString()
+	if suggestion := statusSuggestion(s); suggestion != "" {
+		return base + ": " + suggestion
+	}
+	return base
+}
+
+// statusSuggestion returns an actionable hint for common Cairo error statuses.
+// It returns an empty string for statuses that have no suggestion.
+func statusSuggestion(s Status) string {
+	switch s {
+	case NoCurrentPoint:
+		return "call MoveTo before path operations like LineTo or Arc"
+	case InvalidRestore:
+		return "use Save/Restore in matching pairs; Restore was called without a prior Save"
+	case SurfaceFinished:
+		return "the surface was already destroyed via Close; avoid calling Close before drawing is complete"
+	case NoMemory:
+		return "system is out of memory; try reducing surface dimensions"
+	case FileNotFound:
+		return "verify the file path exists and is accessible"
+	case WriteError:
+		return "check file permissions and available disk space"
+	case ReadError:
+		return "check file permissions and that the file exists at the given path"
+	case InvalidFormat:
+		return "use a supported pixel format such as FormatARGB32 or FormatRGB24"
+	case InvalidStride:
+		return "stride must be at least width*bytes-per-pixel and properly aligned"
+	case SurfaceTypeMismatch:
+		return "the operation requires a different surface type"
+	case PatternTypeMismatch:
+		return "the operation requires a different pattern type"
+	case InvalidMatrix:
+		return "the transformation matrix is degenerate or singular"
+	}
+	return ""
 }
 
 func (s Status) ToError() error {

--- a/status/status.go
+++ b/status/status.go
@@ -3,7 +3,6 @@
 //go:generate stringer -type=Status
 package status
 
-import "fmt"
 
 // Status is used to indicate errors that can occur when using
 // Cairo. In some cases it is returned directly by functions.
@@ -109,9 +108,3 @@ func statusSuggestion(s Status) string {
 	return ""
 }
 
-func (s Status) ToError() error {
-	if s == Success {
-		return nil
-	}
-	return fmt.Errorf("%v", s)
-}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestStatusDescriptiveError verifies that Error() includes actionable suggestions
+// for the most common Cairo error statuses.
+func TestStatusDescriptiveError(t *testing.T) {
+	tests := []struct {
+		status   Status
+		contains string
+	}{
+		{NoCurrentPoint, "MoveTo"},
+		{InvalidRestore, "matching pairs"},
+		{SurfaceFinished, "Close"},
+		{NoMemory, "dimensions"},
+		{FileNotFound, "path"},
+		{WriteError, "permissions"},
+		{ReadError, "permissions"},
+		{InvalidFormat, "FormatARGB32"},
+		{InvalidStride, "aligned"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status.String(), func(t *testing.T) {
+			msg := tt.status.Error()
+			assert.Contains(t, msg, tt.contains,
+				"Error() should include a helpful suggestion for %s", tt.status)
+		})
+	}
+}
+
 // TestStatusSuccess verifies that Success equals 0
 func TestStatusSuccess(t *testing.T) {
 	assert.Equal(t, 0, int(Success), "Success should equal 0")

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -170,51 +170,6 @@ func TestStatusError(t *testing.T) {
 	}
 }
 
-// TestStatusToError verifies that ToError() returns nil for Success and error for others
-func TestStatusToError(t *testing.T) {
-	// Success should return nil
-	t.Run("Success", func(t *testing.T) {
-		err := Success.ToError()
-		assert.NoError(t, err, "Success.ToError() should return nil")
-	})
-
-	// All other statuses should return an error
-	tests := []struct {
-		name   string
-		status Status
-	}{
-		{"NoMemory", NoMemory},
-		{"InvalidRestore", InvalidRestore},
-		{"InvalidPopGroup", InvalidPopGroup},
-		{"NoCurrentPoint", NoCurrentPoint},
-		{"InvalidMatrix", InvalidMatrix},
-		{"InvalidStatus", InvalidStatus},
-		{"NullPointer", NullPointer},
-		{"InvalidString", InvalidString},
-		{"InvalidPathData", InvalidPathData},
-		{"ReadError", ReadError},
-		{"WriteError", WriteError},
-		{"SurfaceFinished", SurfaceFinished},
-		{"SurfaceTypeMismatch", SurfaceTypeMismatch},
-		{"PatternTypeMismatch", PatternTypeMismatch},
-		{"InvalidContent", InvalidContent},
-		{"InvalidFormat", InvalidFormat},
-		{"InvalidVisual", InvalidVisual},
-		{"FileNotFound", FileNotFound},
-		{"InvalidDash", InvalidDash},
-		{"InvalidDscComment", InvalidDscComment},
-		{"InvalidIndex", InvalidIndex},
-		{"ClipNotRepresentable", ClipNotRepresentable},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.status.ToError()
-			assert.Error(t, err, "ToError() should return non-nil error")
-		})
-	}
-}
-
 // TestCGOStatusConversion verifies round-trip conversion between C and Go status codes
 func TestCGOStatusConversion(t *testing.T) {
 	tests := []struct {

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -22,6 +22,9 @@ func TestStatusDescriptiveError(t *testing.T) {
 		{ReadError, "permissions"},
 		{InvalidFormat, "FormatARGB32"},
 		{InvalidStride, "aligned"},
+		{SurfaceTypeMismatch, "different surface type"},
+		{PatternTypeMismatch, "different pattern type"},
+		{InvalidMatrix, "degenerate"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Adds `SurfaceError`, `ContextError`, and `PatternError` types that wrap `status.Status` with additional context (surface type, operation name, pattern type); all support `errors.Is`/`errors.As` via `Unwrap` and custom `Is` methods
- Enriches `status.Status.Error()` with actionable suggestion strings for common Cairo error codes (e.g. `NoCurrentPoint`, `InvalidFormat`, `SurfaceFinished`)
- Wires the new types into all root-package constructors (`NewImageSurface`, `NewContext`, `NewSolidPattern*`, `NewLinearGradient`, `NewRadialGradient`, `NewSurfacePattern`, `NewPDFSurface`, `NewSVGSurface`) via three small helpers (`wrapSurfaceErr`, `wrapContextErr`, `wrapPatternErr`)
- Documents the three-pattern error model (constructor errors, drawing-op status, getter errors) in the README with examples and a common-errors table
- Adds a runnable example (`examples/error_handling.go`) with full test coverage

## Test plan

- [ ] `go test ./...` passes with race detector
- [ ] `errors_test.go` covers `errors.Is`/`errors.As` matching, unwrapping, and error message formatting for all three types
- [ ] `examples/error_handling_test.go` exercises all three error patterns end-to-end against real Cairo calls
- [ ] `status/status_test.go` verifies suggestion strings for each covered status code

## Notes

`status.Status.Error()` now returns a longer string (e.g. `"NoCurrentPoint: call MoveTo before path operations like LineTo or Arc"` instead of `"NoCurrentPoint"`). Any caller matching on the exact error string will be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)